### PR TITLE
TNR-1835: Remove backoff from Pipfile and README.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,6 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-backoff = "*"
 pendulum = "*"
 requests = "*"
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d9da883d05d859401555c823fc1f241970cbdec8ba9dced2ef38572f655e8ade"
+            "sha256": "3e5e2c2404b76f045b21527fb68a84778782b54d109b9e5f9069df9aa096eb6d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -29,13 +29,6 @@
                 "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
             ],
             "version": "==18.2.0"
-        },
-        "backoff": {
-            "hashes": [
-                "sha256:e3df718a774c456a516f7c88516e47a9f2d02aa562943cdfa274c439e9dbbfde"
-            ],
-            "index": "pypi",
-            "version": "==1.6.0"
         },
         "certifi": {
             "hashes": [
@@ -102,11 +95,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:630ff1dbe04f469ee78faa5660f712e58b953da7df22ea5d828c9012e134da43",
-                "sha256:a2b5232735dd0b736cbea9c0f09e5070d78fcaba2823a4f6f09d9a81bd19415c"
+                "sha256:488c842647bbeb350029da10325cb40af0a9c7a2fdda45aeb1dda75b60048ffb",
+                "sha256:c055690dfefa744992f563e8c3a654089a6aa5b8092dded9b6fafbd70b2e45a7"
             ],
             "index": "pypi",
-            "version": "==3.10.0"
+            "version": "==4.0.0"
         },
         "python-dateutil": {
             "hashes": [
@@ -124,11 +117,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c",
-                "sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279"
+                "sha256:65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54",
+                "sha256:ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263"
             ],
             "index": "pypi",
-            "version": "==2.20.0"
+            "version": "==2.20.1"
         },
         "retry": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ print(reviews)
 # Dependencies
 * [requests](https://github.com/requests/requests)
 * [pendulum](https://github.com/sdispater/pendulum)
-* [backoff](https://github.com/litl/backoff)
+* [retry](https://github.com/invl/retry)
 
 # Development
 ```bash


### PR DESCRIPTION
## JIRA Issue
https://vacasait.atlassian.net/browse/TNR-1835

## What
I just noticed that backoff was still in the Pipfile and README.