### PR TITLE
TNR-2236: include translated content in templates

### DIFF
--- a/vacasa/connect/connect.py
+++ b/vacasa/connect/connect.py
@@ -588,7 +588,7 @@ class VacasaConnect:
         Yields:
             An iterator of pages.
         """
-        url = f"{self.endpoint}/v1/pages"
+        url = f"{self.endpoint}/v1/pages?include=content"
         headers = self._headers()
 
         return self._iterate_pages(url, headers, params, retry=retry)


### PR DESCRIPTION
TNR-2236:
added include=content to get template pages.
Using language header did not make a difference in returned content.
We could filter the language here, but then the use of a generator would not make sense.