### PR TITLE
TNR-2916: Don't log invalid 'vacasa-qa' UUIDs.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='VacasaConnect',
-    version='1.0.14',
+    version='1.0.15',
     description='A Python 3.6+ SDK for the connect.vacasa.com API.',
     packages=['vacasa.connect'],
     url='https://github.com/Vacasa/python-vacasa-connect-sdk',

--- a/vacasa/connect/connect.py
+++ b/vacasa/connect/connect.py
@@ -777,8 +777,8 @@ class VacasaConnect:
         if anonymous_id is not None:
             if _is_uuid4(anonymous_id):
                 payload['anonymous_id'] = anonymous_id
-            else:
-                logger.warning("Ignoring invalid UUID4: %s", anonymous_id)
+            elif not anonymous_id.startswith('vacasa-qa-'):
+                logger.info("Ignoring invalid UUID4: %s", anonymous_id)
 
         if terms is not None:
             payload['terms'] = terms


### PR DESCRIPTION
## Jira Issue
https://vacasait.atlassian.net/browse/TNR-2916

## What
Ignore invalid UUIDs used during the QA process.