### PR TITLE
GROW-965: Need to return the error payload!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2019-08-23
+### Fixed
+ - good return on 204 for financial update
+
+### Changes
+ - get, post, and patch now have options to suppress request exception re-raises
+
+
 ## [2.1.0] - 2019-08-19
 ### Added
  - update_contact_finances()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='VacasaConnect',
-    version='2.1.0',
+    version='2.1.1',
     description='A Python 3.6+ SDK for the connect.vacasa.com API.',
     packages=['vacasa.connect'],
     url='https://github.com/Vacasa/python-vacasa-connect-sdk',

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -184,7 +184,8 @@ def test_update_finance_payload(mock_patch):
     connect.update_contact_finances_payload(12345, deepcopy(TEST_DATA['normal_contact_finances']))
     mock_patch.assert_called_once_with('https://fake_url/v1/contacts/12345/finances',
                                       headers=ANY,
-                                      json=deepcopy(TEST_EXPECTED['normal_contact_finances']))
+                                      json=deepcopy(TEST_EXPECTED['normal_contact_finances']),
+                                      request_exceptions=False)
 
 @patch.object(VacasaConnect, '_patch')
 def test_update_finance(mock_patch):
@@ -193,4 +194,5 @@ def test_update_finance(mock_patch):
     connect.update_contact_finances(12340, **deepcopy(TEST_DATA['normal_contact_finances']))
     mock_patch.assert_called_once_with('https://fake_url/v1/contacts/12340/finances',
                                       headers=ANY,
-                                      json=deepcopy(TEST_EXPECTED['normal_contact_finances']))
+                                      json=deepcopy(TEST_EXPECTED['normal_contact_finances']),
+                                      request_exceptions=False)

--- a/vacasa/connect/connect.py
+++ b/vacasa/connect/connect.py
@@ -1,6 +1,7 @@
 """Vacasa Connect Python SDK."""
 import logging
 from urllib.parse import urlparse, urlunparse
+from http import HTTPStatus
 from uuid import UUID
 
 from .idp_auth import IdpAuth
@@ -55,34 +56,34 @@ class VacasaConnect:
         }
 
     @staticmethod
-    def _get(url, headers: dict = None, params: dict = None):
+    def _get(url, headers: dict = None, params: dict = None, request_exceptions: bool = True):
         """HTTP GET request helper."""
         if headers is None:
             headers = {}
 
         r = requests.get(url, headers=headers, params=params)
-        log_http_error(r)
+        log_http_error(r, request_exceptions)
 
         return r
 
     @staticmethod
-    def _post(url, data: dict = None, json: dict = None, headers: dict = None):
+    def _post(url, data: dict = None, json: dict = None, headers: dict = None, request_exceptions: bool = True):
         """HTTP POST request helper."""
         if not headers:
             headers = {}
 
         r = requests.post(url, data=data, json=json, headers=headers)
-        log_http_error(r)
+        log_http_error(r, request_exceptions)
 
         return r
 
     @staticmethod
-    def _patch(url, data: dict = None, json: dict = None, headers: dict = None):
+    def _patch(url, data: dict = None, json: dict = None, headers: dict = None, request_exceptions: bool = True):
         """HTTP PATCH request helper."""
         if not headers:
             headers = {}
         r = requests.patch(url, data=data, json=json, headers=headers)
-        log_http_error(r)
+        log_http_error(r, request_exceptions)
 
         return r
 
@@ -1277,7 +1278,11 @@ class VacasaConnect:
         """
 
         url = f"{self.endpoint}/v1/contacts/{contact_id}/finances"
-        return self._patch(url, json={'data': {'attributes': params}}, headers=self._headers()).json()
+        r = self._patch(url, json={'data': {'attributes': params}}, headers=self._headers(), request_exceptions=False)
+        if r.status_code == HTTPStatus.NO_CONTENT:
+            return None
+        else:
+            return r.json()
 
 
 

--- a/vacasa/connect/util.py
+++ b/vacasa/connect/util.py
@@ -6,7 +6,7 @@ from requests import Response, RequestException
 logger = logging.getLogger(__name__)
 
 
-def log_http_error(r: Response):
+def log_http_error(r: Response, reraise: bool = True):
     """ Log any 4XX/5XX error responses and re-raise """
     try:
         r.raise_for_status()
@@ -15,7 +15,8 @@ def log_http_error(r: Response):
             logger.exception(r.json())
         except ValueError:
             logger.exception(r.content)
-        raise e
+        if reraise:
+            raise e
 
 
 def is_https_url(url: str) -> bool:


### PR DESCRIPTION
Was incorrectly calling `.json()` when in the 204 return case there is no payload.
Also changed things so that the error payload can be forwarded along elsewhere.