### PR TITLE
TNR-2993 adding discounId to create res seed method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [2.2.2] - 2019-09-25
+### Added
+ - param `discount_id` to the `create_reservation_seed()` method, which uses [v1/reservations-seed](https://connect.vacasa.com/#operation/post-reservations-seed)
+
 # [2.2.1] - 2019-09-23
 ### Added
  - The `create_reservation_seed()` method, which uses [v1/reservations-seed](https://connect.vacasa.com/#operation/post-reservations-seed)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='VacasaConnect',
-    version='2.2.1',
+    version='2.2.2',
     description='A Python 3.6+ SDK for the connect.vacasa.com API.',
     packages=['vacasa.connect'],
     url='https://github.com/Vacasa/python-vacasa-connect-sdk',

--- a/vacasa/connect/connect.py
+++ b/vacasa/connect/connect.py
@@ -904,6 +904,7 @@ class VacasaConnect:
                                 departure: str,
                                 booked_currency_code: str,
                                 quote_id: str,
+                                discount_id: int = None,
                                 source: str = None,
                                 anonymous_id: str = None):
         """
@@ -915,6 +916,7 @@ class VacasaConnect:
             booked_currency_code: The currency of record for the unit being
                 booked in ISO 4217 alpha code format (e.g. 'USD', 'CLP', etc.).
             quote_id: ID of a quote retrieved from the `GET /quotes` endpoint
+            discount_id: ID of the discount used or None
             source: A Vacasa-issued code identifying the source of this request
             anonymous_id (optional): UUID4 for tracking
 
@@ -930,6 +932,9 @@ class VacasaConnect:
             unit_id=unit_id,
             quote_id=quote_id
         )
+
+        if discount_id is not None:
+            payload['discount_id'] = discount_id
 
         if source is not None:
             payload['source'] = source


### PR DESCRIPTION
Added discount_id as a param to the `create_reservation_seed`. 

This is from TNR-2993 comment from Brain Murray. "Contrary to the documentation for the new Create Reservation Seed endpoint, you actually can pass in a discount_id"