### PR TITLE
TNR-4128: Add support for reservation seeds w/o quote ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.19.0] - 2020-12-07
+## Added
+- Added `create_reservation_seed_from_finances()` to support new `/v1/reservations-seed` functionality
+
 ## [4.18.0] - 2020-12-02
 ## Changed
 - Modified `update_contact_finances()` to accept new parameters for changing W9 fields.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='VacasaConnect',
-    version='4.18.0',
+    version='4.19.0',
     description='A Python 3.6+ SDK for the connect.vacasa.com API.',
     packages=['vacasa.connect'],
     url='https://github.com/Vacasa/python-vacasa-connect-sdk',

--- a/vacasa/connect/connect.py
+++ b/vacasa/connect/connect.py
@@ -1292,10 +1292,9 @@ class VacasaConnect:
                                               arrival: str,
                                               departure: str,
                                               adults: int,
-                                              children: int = 0,
-                                              pets: int = 0,
-                                              source: str = None,
-                                              anonymous_id: str = None,
+                                              children: int,
+                                              pets: int,
+                                              source: str,
                                               ):
         """ Create a "seed" reservation (missing guest/payment info).  Requires finance details from a valid quote """
         url = f"{self.endpoint}/v1/reservations-seed"
@@ -1312,13 +1311,8 @@ class VacasaConnect:
             adults=adults,
             children=children,
             pets=pets,
+            source=source
         )
-
-        if source is not None:
-            payload['source'] = source
-
-        if anonymous_id:
-            payload['anonymous_id'] = anonymous_id
 
         return self._post(url, json={'data': {'attributes': payload}}, headers=headers).json()
 
@@ -1774,7 +1768,6 @@ class VacasaConnect:
             tax_form_code_id=tax_form_code_id,
             tax_id=tax_id
         ))
-
 
     def update_contact_finances_payload(self, contact_id, params: dict):
         """

--- a/vacasa/connect/connect.py
+++ b/vacasa/connect/connect.py
@@ -1,5 +1,6 @@
 """Vacasa Connect Python SDK."""
 import logging
+from typing import List
 from urllib.parse import urlparse, urlunparse
 from uuid import UUID
 
@@ -1252,7 +1253,7 @@ class VacasaConnect:
                                 created_by: int,
                                 source: str = None,
                                 anonymous_id: str = None):
-        """
+        """ Create a "seed" reservation (missing guest/payment info).  Requires a /v1/quotes ID
 
         Args:
             booked_currency_code: The currency of record for the unit being
@@ -1271,6 +1272,46 @@ class VacasaConnect:
             booked_currency_code=booked_currency_code,
             quote_id=quote_id,
             created_by=created_by
+        )
+
+        if source is not None:
+            payload['source'] = source
+
+        if anonymous_id:
+            payload['anonymous_id'] = anonymous_id
+
+        return self._post(url, json={'data': {'attributes': payload}}, headers=headers).json()
+
+    def create_reservation_seed_from_finances(self,
+                                              booked_currency_code: str,
+                                              created_by: int,
+                                              unit_id: int,
+                                              fees: List[dict],
+                                              rent: List[dict],
+                                              taxes: List[dict],
+                                              arrival: str,
+                                              departure: str,
+                                              adults: int,
+                                              children: int = 0,
+                                              pets: int = 0,
+                                              source: str = None,
+                                              anonymous_id: str = None,
+                                              ):
+        """ Create a "seed" reservation (missing guest/payment info).  Requires finance details from a valid quote """
+        url = f"{self.endpoint}/v1/reservations-seed"
+        headers = self._headers()
+        payload = dict(
+            booked_currency_code=booked_currency_code,
+            created_by=created_by,
+            unit_id=unit_id,
+            fees=fees,
+            rent=rent,
+            taxes=taxes,
+            arrival=arrival,
+            departure=departure,
+            adults=adults,
+            children=children,
+            pets=pets,
         )
 
         if source is not None:


### PR DESCRIPTION
## JIRA Issue
https://vacasait.atlassian.net/browse/TNR-4128

## What
Add support for reservation seeds w/o quote ID (allows us to use new quote service implementation)

##  PR Checklist
- [x] Updated `CHANGELOG.md`
- [x] Updated version in `setup.py`
