### PR TITLE
TRAP-1511 Add get unit bulk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.21.5] - 2021-09-07
+## [4.22.0] - 2021-09-07
 ## Changed
 - Added `get_unit_bulk` to support `/v1/unit-bulk` functionality.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.21.5] - 2021-09-07
+## Changed
+- Added `get_unit_bulk` to support `/v1/unit-bulk` functionality.
+
 ## [4.21.4] - 2021-09-07
 ## Changed
 - Updated the python dependencies in response to Dependabot alerts.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='VacasaConnect',
-    version='4.21.4',
+    version='4.21.5',
     description='A Python 3.6+ SDK for the connect.vacasa.com API.',
     packages=['vacasa.connect'],
     url='https://github.com/Vacasa/python-vacasa-connect-sdk',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='VacasaConnect',
-    version='4.21.5',
+    version='4.22.0',
     description='A Python 3.6+ SDK for the connect.vacasa.com API.',
     packages=['vacasa.connect'],
     url='https://github.com/Vacasa/python-vacasa-connect-sdk',

--- a/vacasa/connect/connect.py
+++ b/vacasa/connect/connect.py
@@ -2067,6 +2067,14 @@ class VacasaConnect:
 
         return self._iterate_pages(url, headers, params)
 
+    def get_unit_bulk(self, ids: str):
+        """ Get a list of units using POST method to avoid the URL max length limit of GET method"""
+        url = f"{self.endpoint}/v1/unit-bulk"
+        headers = self._headers()
+        payload = dict(ids=ids)
+
+        return self._post(url, json={'data': {'attributes': payload}}, headers=headers).json()
+
 
 def _trip_protection_to_integer(trip_protection: bool) -> int:
     """Convert from True/False/None to 1/0/-1"""


### PR DESCRIPTION
## JIRA Issue
https://vacasait.atlassian.net/browse/TRAP-1511

## What

Added get unit bulk, this method is using a POST request instead of a GET to bypass the max limit of the URL size (to send a long string of ids).

##  PR Checklist
- [X] Updated `CHANGELOG.md`
- [X] Updated version in `setup.py`
