### PR TITLE
Making cryptography version range more explicit to try and solve prob…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.27.1] - 2023-02-02
+
+## Changed
+
+- Made cryptography version range in extras_require more explicit to attempt to resolve a setup command error
+
 ## [4.27.0] - 2022-09-07
 
 ## Changed

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         'python-jose==3.*'
     ],
     extras_require={
-        "cryptography": ['cryptography>=3.*']
+        "cryptography": ['cryptography>=3.4.8']
     },
     long_description=open('README.md').read()
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='VacasaConnect',
-    version='4.27.0',
+    version='4.27.1',
     description='A Python 3.6+ SDK for the connect.vacasa.com API.',
     packages=['vacasa.connect'],
     url='https://github.com/Vacasa/python-vacasa-connect-sdk',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         'python-jose==3.*'
     ],
     extras_require={
-        "cryptography": ['cryptography>=3.4.8']
+        "cryptography": ['cryptography==3.*']
     },
     long_description=open('README.md').read()
 )


### PR DESCRIPTION
…lem with invalid version range

## JIRA Issue
N/A

## What
I'm getting an error when trying to build Ecomm API that originates from this library: 
`error in setup command: 'extras_require' must be a dictionary whose values are strings or lists of strings containing valid project/version requirement specifiers. cryptography`

Attempting to resolve the error by making the version range more explicit

##  PR Checklist
- [x] Updated `CHANGELOG.md`
- [x] Updated version in `setup.py`
