### PR TITLE
Updating crypto version to be exactly 3.4.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         'python-jose==3.*'
     ],
     extras_require={
-        "cryptography": ['cryptography==3.*']
+        "cryptography": ['cryptography==3.4.8']
     },
     long_description=open('README.md').read()
 )


### PR DESCRIPTION
## JIRA Issue
N/A

## What
Updating crypto version to be exactly 3.4.8

##  PR Checklist
Done in this PR: https://github.com/Vacasa/python-vacasa-connect-sdk/pull/131
- [x] Updated `CHANGELOG.md`
- [x] Updated version in `setup.py`
